### PR TITLE
Update requirements.txt add ipympl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.24.2
 sympy==1.11.1
 matplotlib==3.6.3
 
+ipympl


### PR DESCRIPTION
Add ipympl, since it seems that matplotlib notebook no longer works. See https://stackoverflow.com/questions/77759663/how-to-resolve-javascript-error-ipython-is-not-defined-while-trying-to-plot-i